### PR TITLE
Add warning paragraph and button for optional info

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This project contains a single HTML page that lists device information that your
 - Screen resolution and color depth
 - Network connection information
 - Time zone
-- Optional geolocation and media devices (may prompt for permission)
+- Optional geolocation and media devices (may prompt for permission after
+  clicking the "Collect Location and Media Info" button)
 
 Everything runs in the browser—no network requests are required.

--- a/index.html
+++ b/index.html
@@ -10,6 +10,8 @@
 </head>
 <body>
   <h1>Browser Device Information</h1>
+  <p id="notice">This page may ask to access your location and media devices. All information stays in your browser and is not sent anywhere.</p>
+  <button id="collect-btn">Collect Location and Media Info</button>
   <dl id="info"></dl>
   <script>
     const info = {
@@ -45,24 +47,30 @@
       addEntry(key, value);
     }
 
-    if (navigator.mediaDevices && navigator.mediaDevices.enumerateDevices) {
-      navigator.mediaDevices.enumerateDevices()
-        .then(devices => {
-          const descriptions = devices.map(d => d.kind + ': ' + (d.label || 'hidden by permission'));
-          addEntry('Media Devices', descriptions.join('; '));
-        })
-        .catch(err => addEntry('Media Devices', 'Error: ' + err));
+    function collectOptionalInfo() {
+      if (navigator.mediaDevices && navigator.mediaDevices.enumerateDevices) {
+        navigator.mediaDevices.enumerateDevices()
+          .then(devices => {
+            const descriptions = devices.map(d => d.kind + ': ' + (d.label || 'hidden by permission'));
+            addEntry('Media Devices', descriptions.join('; '));
+          })
+          .catch(err => addEntry('Media Devices', 'Error: ' + err));
+      }
+
+      if (navigator.geolocation) {
+        navigator.geolocation.getCurrentPosition(
+          position => {
+            addEntry('Latitude', position.coords.latitude);
+            addEntry('Longitude', position.coords.longitude);
+          },
+          err => addEntry('Geolocation', 'Error: ' + err.message)
+        );
+      }
+
+      document.getElementById('collect-btn').disabled = true;
     }
 
-    if (navigator.geolocation) {
-      navigator.geolocation.getCurrentPosition(
-        position => {
-          addEntry('Latitude', position.coords.latitude);
-          addEntry('Longitude', position.coords.longitude);
-        },
-        err => addEntry('Geolocation', 'Error: ' + err.message)
-      );
-    }
+    document.getElementById('collect-btn').addEventListener('click', collectOptionalInfo);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- warn that optional location or media queries may prompt for permission and stay in the browser
- add a button to collect location and media data instead of doing so automatically
- update README instructions for the new button

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6848fa1e441483259c95a0f044a1a8b7